### PR TITLE
Add basic settings management

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,8 @@ function App() {
   const [page, setPage] = useState<Page>('welcome');
   const [user, setUser] = useState<string>('');
   const [pairs, setPairs] = useState<number>(4);
+  const [soundOn, setSoundOn] = useState<boolean>(true);
+  const [theme, setTheme] = useState<'dark' | 'light'>('dark');
 
   const goAuth = () => setPage('auth');
   const goMode = () => setPage('mode');
@@ -71,7 +73,17 @@ function App() {
       case 'game':
         return <GameScreenPage pairs={pairs} onFinish={goMode} onSettings={goSettings} />;
       case 'settings':
-        return <SettingsPage onBack={goMode} />;
+        return (
+          <SettingsPage
+            user={user}
+            onUserChange={setUser}
+            soundOn={soundOn}
+            onToggleSound={() => setSoundOn(prev => !prev)}
+            theme={theme}
+            onThemeChange={setTheme}
+            onBack={goMode}
+          />
+        );
       default:
         return <WelcomePage onSinglePlayer={goAuth} onMultiPlayer={goAuth} onSettings={goSettings} />;
     }

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -4,16 +4,58 @@ import Footer from '../components/Footer';
 import Button from '../components/Button';
 
 interface SettingsPageProps {
+  user: string;
+  onUserChange: (name: string) => void;
+  soundOn: boolean;
+  onToggleSound: () => void;
+  theme: 'dark' | 'light';
+  onThemeChange: (theme: 'dark' | 'light') => void;
   onBack: () => void;
 }
 
-const SettingsPage: React.FC<SettingsPageProps> = ({ onBack }) => (
+const SettingsPage: React.FC<SettingsPageProps> = ({
+  user,
+  onUserChange,
+  soundOn,
+  onToggleSound,
+  theme,
+  onThemeChange,
+  onBack,
+}) => (
   <div className="min-h-screen flex flex-col bg-[#101a23] text-white">
     <Header />
     <div className="flex-1 flex flex-col items-center p-4">
       <h1 className="text-2xl font-bold mb-4">Settings</h1>
-      <p className="text-[#90adcb] mb-6 text-center">User profile and game preferences will appear here.</p>
-      <Button onClick={onBack}>Back</Button>
+      <div className="w-full max-w-xs flex flex-col gap-4">
+        <label className="flex flex-col text-left">
+          <span className="mb-1 font-bold">User Name</span>
+          <input
+            className="rounded-xl px-3 py-2 text-black"
+            value={user}
+            onChange={(e) => onUserChange(e.target.value)}
+          />
+        </label>
+        <label className="flex items-center gap-2">
+          <input type="checkbox" checked={soundOn} onChange={onToggleSound} />
+          <span>Sound</span>
+        </label>
+        <label className="flex flex-col text-left">
+          <span className="mb-1 font-bold">Theme</span>
+          <select
+            className="rounded-xl px-3 py-2 text-black"
+            value={theme}
+            onChange={(e) =>
+              onThemeChange(e.target.value as 'dark' | 'light')
+            }
+          >
+            <option value="dark">Dark</option>
+            <option value="light">Light</option>
+          </select>
+        </label>
+      </div>
+      <div className="mt-6">
+        <Button onClick={onBack}>Back</Button>
+      </div>
     </div>
     <Footer />
   </div>


### PR DESCRIPTION
## Summary
- implement interactive Settings page for changing username, theme, and sound toggle
- manage settings state in `App`

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684719776ca08330a4ef9dd5e602bca9